### PR TITLE
feat : badge 컴포넌트 생성 및 스타일링

### DIFF
--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,4 +1,5 @@
 import styles from './page.module.scss';
+
 export default function Home() {
     return (
         <div>

--- a/front/components/Badge/Badge.module.scss
+++ b/front/components/Badge/Badge.module.scss
@@ -1,0 +1,29 @@
+.badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 25px;
+    font-weight: bold;
+    cursor: pointer;
+    color: var(--white-color);
+    background-color: var(--brand-color);
+    padding: 5px 10px;
+}
+
+.sm {
+    width: 46px;
+    height: 16px;
+}
+
+.md {
+    width: 93px;
+    height: 25px;
+}
+
+.outlined {
+    border: 2px solid var(--disabled-color);
+}
+
+.filled {
+    border: none;
+}

--- a/front/components/Badge/Badge.tsx
+++ b/front/components/Badge/Badge.tsx
@@ -1,0 +1,21 @@
+import styles from './Badge.module.scss';
+import { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+
+interface Props extends HTMLAttributes<HTMLSpanElement> {
+    children: ReactNode;
+    size?: 'sm' | 'md';
+    backgroundColor?: CSSProperties['backgroundColor'];
+    variant?: 'outlined' | 'filled';
+}
+
+const Badge = (props: Props) => {
+    const { children, size = 'md', backgroundColor, variant = 'filled' } = props;
+
+    return (
+        <span className={`${styles.badge} ${styles[size]} ${styles[variant]}`} style={{ backgroundColor }}>
+            {children}
+        </span>
+    );
+};
+
+export default Badge;


### PR DESCRIPTION
## 개요
공통 UI로 사용할 수 있는 Badge(뱃지) 컴포넌트를 추가했습니다.  
size, backgroundColor, variant(filled/outlined)를 props로 받아 재사용 가능하도록 구성했습니다.

## 주요 변경사항
- `<Badge>` 공용 컴포넌트 생성
- size (`sm`, `md`)에 따른 스타일 분리 ,  size 기본값은 md 입니다. 
- variant (`filled`, `outlined`) 스타일 분기 처리, variant 의 기본값은 filled 입니다.
- CSS 변수 기반 컬러 매핑 적용 (ex. `--color-success`, `--color-primary`, 'red', 'green' 등) 
- 배경색 기본값은 '--brand-color ' 입니다.

## 사용 예시
```tsx
<Badge size="sm" color="red" variant="outlined">
  수락됨
</Badge>
