### PR TITLE
기술 스택 셀렉트박스 구현

### DIFF
--- a/front/app/globals.scss
+++ b/front/app/globals.scss
@@ -19,4 +19,5 @@
     --mobile-max-width: 480px;
     --web-max-width: 1280px;
     // --mobile-min-width: 320px;
+    // hi
 }

--- a/front/components/SelectBox/page.module.scss
+++ b/front/components/SelectBox/page.module.scss
@@ -1,0 +1,47 @@
+.selectBox {
+    display: inline-block;
+    padding: 10px 16px;
+    align-items: center;
+
+    width: 60px;
+    height: 20px;
+
+    font-size: 16px;
+    border: 1px solid #e3e3e3;
+    border-radius: 8px;
+
+    background-color: white;
+    color: #646464;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+}
+
+.modal {
+    width: 100%;
+    max-width: 900px;
+    background-color: white;
+    border: 1px solid #dddddd;
+    border-radius: 13px;
+    z-index: 10;
+    padding: 8px 4px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.option {
+    display: flex;
+    padding: 10px 10px;
+    cursor: pointer;
+    font-size: 1rem;
+    text-align: center; /* 텍스트 가운데 정렬 */
+    box-sizing: border-box; /* 패딩 포함 크기 계산 */
+    border: 1px solid #e3e3e3;
+    border-radius: 20px;
+}
+.notSelected {
+    opacity: 0.4; /* 연하게 표시 */
+}

--- a/front/components/SelectBox/page.tsx
+++ b/front/components/SelectBox/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import styles from './page.module.scss';
+import React, { useState } from 'react';
+
+interface SelectBoxProps {
+    options: string[];
+}
+
+export default function SelectBox({ options }: SelectBoxProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+
+    const toggleModal = () => {
+        setIsOpen(!isOpen);
+    };
+
+    const handleOptionClick = (option: string) => {
+        if (selectedOptions.includes(option)) {
+            setSelectedOptions(selectedOptions.filter((item) => item !== option));
+        } else {
+            setSelectedOptions([...selectedOptions, option]);
+        }
+    };
+
+    return (
+        <div>
+            <div onClick={toggleModal} className={styles.selectBox}>
+                {selectedOptions.length > 0 ? selectedOptions.join(', ') : '기술 스택'}
+            </div>
+            {isOpen && (
+                <div className={styles.modal}>
+                    {options.map((option) => (
+                        <div
+                            key={option}
+                            onClick={() => handleOptionClick(option)}
+                            className={`${styles.option} ${
+                                selectedOptions.length === 0
+                                    ? '' // 아무것도 선택하지 않았을 때 기본 스타일
+                                    : selectedOptions.includes(option)
+                                    ? '' // 선택된 옵션
+                                    : styles.notSelected // 선택되지 않은 옵션
+                            }`}
+                        >
+                            {option}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## 개요
공통 UI로 사용할 수 있는 selectBox 컴포넌트를 추가했습니다.  
options를 props로 받아 재사용 가능하도록 구성했습니다.

## 주요 변경사항
- `<SelectBox>` 공용 컴포넌트 생성

## 사용 예시
```tsx
const options = [
        'Option 1',
        'JavaScript',
        'dongsuIsBestBestBestBest',
        'Option 4',
        'Option 5',
        'Option 6',
        'Option 7',
        'Option 8',
    ];

    return (
        <div>
            <SelectBox options={options} />
        </div>
    );
```
이런식으로 options를 props로 전달하면 됩니다.
