### PR TITLE
Feat : 레이아웃 처리를 위한 LayoutProvider 및 useDeviceLayout 구현

### DIFF
--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -1,3 +1,4 @@
+import { DeviceLayoutProvider } from '@/providers/DeviceLayoutProvider';
 import './globals.scss';
 import './reset.css';
 
@@ -8,7 +9,9 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="ko">
-            <body>{children}</body>
+            <body>
+                <DeviceLayoutProvider>{children}</DeviceLayoutProvider>
+            </body>
         </html>
     );
 }

--- a/front/components/Badge/SkillBadge.tsx
+++ b/front/components/Badge/SkillBadge.tsx
@@ -1,0 +1,9 @@
+const SkillBadge = () => {
+    return (
+        <div>
+            <span></span>
+        </div>
+    );
+};
+
+export default SkillBadge;

--- a/front/hooks/useDeviceSize.tsx
+++ b/front/hooks/useDeviceSize.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export const DEVICE_BREAKPOINTS = {
+    mobile: 480,
+    tablet: 768,
+    desktop: 1280,
+};
+
+type DeviceType = keyof typeof DEVICE_BREAKPOINTS;
+
+export const useDeviceSize = () => {
+    const [layoutWidth, setLayoutWidth] = useState(DEVICE_BREAKPOINTS.desktop);
+
+    const getDeviceType = (width: number): DeviceType => {
+        if (width < DEVICE_BREAKPOINTS.mobile) return 'mobile';
+        if (width < DEVICE_BREAKPOINTS.tablet) return 'tablet';
+        return 'desktop';
+    };
+
+    useEffect(() => {
+        const updateSize = () => {
+            const currentWidth = window.innerWidth;
+            const type = getDeviceType(currentWidth);
+
+            setLayoutWidth(DEVICE_BREAKPOINTS[type]);
+        };
+
+        updateSize();
+        window.addEventListener('resize', updateSize);
+
+        return () => window.removeEventListener('resize', updateSize);
+    }, []);
+
+    return { innerWidth: layoutWidth };
+};

--- a/front/providers/DeviceLayoutProvider.tsx
+++ b/front/providers/DeviceLayoutProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { DEVICE_BREAKPOINTS, useDeviceSize } from '@/hooks/useDeviceSize';
+import React, { createContext, ReactNode, useContext } from 'react';
+
+export const useMobileContainerWidth = () => {
+    return useContext(ScreenContext);
+};
+
+export const ScreenContext = createContext(DEVICE_BREAKPOINTS.desktop);
+
+export const DeviceLayoutProvider = ({ children }: { children: ReactNode }) => {
+    const { innerWidth } = useDeviceSize();
+
+    return (
+        <ScreenContext.Provider value={innerWidth}>
+            <div
+                style={{
+                    maxWidth: innerWidth,
+                    marginLeft: 'auto',
+                    marginRight: 'auto',
+                }}
+            >
+                {children}
+            </div>
+        </ScreenContext.Provider>
+    );
+};


### PR DESCRIPTION
## 개요

반응형 UI 처리를 위한 DeviceLayoutProvider와 useDeviceSize 훅을 추가하여, 클라이언트 측 디바이스 너비에 따라 동적으로 레이아웃을 구성할 수 있도록 했습니다.

## 주요 변경사항

<DeviceLayoutProvider> 컴포넌트 추가

Context API를 활용하여 디바이스 사이즈 상태를 전역에서 관리
resize 이벤트를 통해 브라우저 너비 변화 감지 및 업데이트

<useDeviceSize> 커스텀 훅 구현

현재 디바이스의 레이아웃 타입 (mobile, tablet, desktop)을 반환
컴포넌트 단에서 간편하게 디바이스 정보를 가져와 조건부 렌더링 가능

프로젝트 구조 정리

루트 디렉토리에 providers, hooks 폴더 추가
DeviceLayoutProvider를 root layout 에서 전역으로 감싸도록 적용

## 사용 

```
   <body>
         <DeviceLayoutProvider>{children}</DeviceLayoutProvider>
   </body>
```