### PR TITLE
props 전달 방식 수정하였습니다.

### DIFF
--- a/front/components/SelectBox/page.tsx
+++ b/front/components/SelectBox/page.tsx
@@ -4,22 +4,27 @@ import React, { useState } from 'react';
 
 interface SelectBoxProps {
     options: string[];
+    handler: (selectedOptions: string[]) => void; // 콜백 함수 타입 정의
 }
 
-export default function SelectBox({ options }: SelectBoxProps) {
+export default function SelectBox({ options, handler }: SelectBoxProps) {
     const [isOpen, setIsOpen] = useState(false);
-    const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
 
     const toggleModal = () => {
         setIsOpen(!isOpen);
     };
 
+    const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
+
     const handleOptionClick = (option: string) => {
+        let updatedOptions;
         if (selectedOptions.includes(option)) {
-            setSelectedOptions(selectedOptions.filter((item) => item !== option));
+            updatedOptions = selectedOptions.filter((item) => item !== option);
         } else {
-            setSelectedOptions([...selectedOptions, option]);
+            updatedOptions = [...selectedOptions, option];
         }
+        setSelectedOptions(updatedOptions);
+        handler(updatedOptions); // 부모 컴포넌트로 선택된 옵션 전달
     };
 
     return (


### PR DESCRIPTION
## 개요
selectBox를 사용하실때 options라는 문자열 배열과 선택한 옵션값을 가져와 set하는 useState함수를 handler로 전달하여 선택한 값들을 사용할 수 있습니다
## 주요 변경사항
- `<SelectBox>` props 추가

## 사용 예시
```tsx
const options = [
        'Option 1',
        'JavaScript',
        'dongsuIsBestBestBestBest',
        'Option 4',
        'Option 5',
        'Option 6',
        'Option 7',
        'Option 8',
    ];
const [selectedOptions, setSelectedOptions] = useState<string[]>([]);

    return (
        <div>
            <SelectBox options={options} handler={setSelectedOptions}/>
        </div>
    );
```
이런식으로 options를 props로 전달하면 됩니다.
