### PR TITLE
Card component 구현 및 스타일링

### DIFF
--- a/front/app/globals.scss
+++ b/front/app/globals.scss
@@ -10,6 +10,7 @@
     --disabled-color: #c9c9c9;
     --cancel-button-color: #f13f6f;
     --confirm-button-color: #D5EFFE;
+    --project-color: #0064FF;
     --lion-color: #ffa928;
     --header-size: 2.5rem;
     --content-size: 1.2rem;

--- a/front/components/Card/Card.module.scss
+++ b/front/components/Card/Card.module.scss
@@ -1,0 +1,42 @@
+.card {
+    border: 0.0625rem solid var(--disabled-color); // 1px -> 0.0625rem
+    border-radius: 0.625rem; // 10px -> 0.625rem
+    margin: 1.875rem; // 30px -> 1.875rem
+    padding: 1.25rem; // 20px -> 1.25rem
+    width: 18.75rem; // 300px -> 18.75rem
+    height: 12.5rem; // 200px -> 12.5rem
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    box-shadow: 0.1875rem 0.1875rem 0.375rem rgba(0, 0, 0, 0.1); // 3px -> 0.1875rem, 6px -> 0.375rem
+    overflow: hidden;
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
+
+    &:hover {
+        box-shadow: 0.3125rem 0.3125rem 0.625rem rgba(0, 0, 0, 0.2); // 5px -> 0.3125rem, 10px -> 0.625rem
+        transform: scale(1.05);
+    }
+}
+
+.cardHeader {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 0.5rem; // 8px -> 0.5rem
+}
+
+.cardBody {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem; // 16px -> 1rem
+    width: 100%;
+}
+
+.cardFooter {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.8125rem;
+}
+

--- a/front/components/Card/Card.tsx
+++ b/front/components/Card/Card.tsx
@@ -1,0 +1,24 @@
+import React, { FC, ReactNode } from "react";
+import styles from "./Card.module.scss";
+
+type CardProps = {
+    header?: ReactNode; // 상단 커스터마이징
+    body: ReactNode; // 본문 커스터마이징
+    footer?: ReactNode; // 하단 커스터마이징
+};
+
+const Card: FC<CardProps> = ({ header, body, footer, ...props }) => {
+    return (
+        <div className={styles.card} {...props}>
+            {/* 상단: header는 있으면 렌더링 */}
+            <div className={styles.cardHeader}>{header}</div>
+
+            <div className={styles.cardBody}>{body}</div>
+
+            {/* 하단: footer가 있으면 렌더링 */}
+            {footer && <div className={styles.cardFooter}>{footer}</div>}
+        </div>
+    );
+};
+
+export default Card;


### PR DESCRIPTION
## 개요  
공통 UI로 사용할 수 있는 `Card` 컴포넌트를 구현했습니다.  
`header`, `body`, `footer` 영역으로 분리하여 유연하게 내용 구성 및 커스터마이징이 가능합니다.

## Card  
### Props  
| 이름     | 타입                              | 설명                               |
|--------|----------------------------------|----------------------------------|
| header | `ReactNode` _(optional)_         | 카드 상단 영역, 제목이나 카테고리 등을 전달 |
| body   | `ReactNode` **(required)**       | 카드 본문 영역, 주요 콘텐츠가 위치함     |
| footer | `ReactNode` _(optional)_         | 카드 하단 영역, 찜하기 등 부가 내용   |

### 스타일 기준  
- `card` 자체는 `border`, `box-shadow`, `hover 효과`, `padding` 등 기본 스타일을 가짐  
- 내부 요소는 `cardHeader`, `cardBody`, `cardFooter` 클래스로 구분하여 레이아웃 분리  
- `cardBody`는 `space-between` 정렬을 통해 텍스트와 이미지를 양쪽 끝에 배치

### 사용 예시  

```tsx
<Card
  header={<span>header입니다.</span>}
  body={<span>body입니다.</span>}
  footer={<span>footer입니다.</span>}
/>
