### PR TITLE
Feat : 공용 Input 컴포넌트 및 Label 컴포넌트 생성

### DIFF
--- a/fitple/components/Input/Input.module.scss
+++ b/fitple/components/Input/Input.module.scss
@@ -1,0 +1,42 @@
+.layout {
+    position: relative;
+    width: 100%;
+    display: flex;
+}
+
+.input {
+    width: 100%;
+    padding: 0 10px 8px;
+    height: 42px;
+    font-size: 18px;
+    border-radius: 8px;
+    border: none;
+    outline: none;
+    caret-color: var(--brand-color);
+}
+
+.filled {
+    background-color: var(--mobile-input-color);
+}
+
+.outlined {
+    background-color: var(--background-color);
+    border: 1px solid var(--mobile-input-color);
+    color: var(--mobile-input-color);
+}
+
+.error {
+    color: red;
+    border-bottom-color: #f44336;
+
+    &:focus {
+        border-bottom-color: #f44336;
+    }
+}
+
+.btn {
+    position: absolute;
+    right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/fitple/components/Input/Input.tsx
+++ b/fitple/components/Input/Input.tsx
@@ -1,0 +1,21 @@
+import { InputHTMLAttributes, ReactElement } from 'react';
+import styles from './Input.module.scss';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    hasError?: boolean;
+    renderRight?: ReactElement;
+    variant?: 'outlined' | 'filled';
+}
+
+const Input: React.FC<Props> = (props) => {
+    const { hasError, renderRight, variant = 'filled', ...rest } = props;
+
+    return (
+        <div className={styles.layout}>
+            <input className={`${styles.input} ${styles[variant]} ${hasError ? styles.error : ''}`} {...rest} />
+            {renderRight ? <div className={styles.btn}>{renderRight}</div> : null}
+        </div>
+    );
+};
+
+export default Input;

--- a/fitple/components/Input/Label.module.scss
+++ b/fitple/components/Input/Label.module.scss
@@ -1,0 +1,34 @@
+.layout {
+    gap: 15px;
+    color: var(--white-color);
+    font-size: 1.1rem;
+}
+
+.column {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    gap: 15px;
+}
+
+.hasError {
+    color: #f44336;
+    text-align: center;
+    font-size: 0.9rem;
+    display: 'inline-block';
+    margin-top: 10px;
+}
+
+.label {
+    display: flex;
+    width: fit-content;
+    align-items: center;
+    min-width: 80px;
+    text-align: center;
+    justify-content: center;
+}

--- a/fitple/components/Input/Label.tsx
+++ b/fitple/components/Input/Label.tsx
@@ -1,0 +1,25 @@
+import { HTMLAttributes, ReactNode } from 'react';
+import styles from './Label.module.scss';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+    label?: ReactNode;
+    children: ReactNode;
+    bottomText?: string;
+    direction?: 'row' | 'column';
+}
+
+const Label: React.FC<Props> = (props) => {
+    const { label, children, bottomText, direction = 'column' } = props;
+
+    return (
+        <div className={`${styles.layout}`}>
+            <div className={styles[direction]}>
+                <label className={styles.label}>{label}</label>
+                {children}
+            </div>
+            {bottomText != null ? <p className={styles.hasError}>{bottomText}</p> : null}
+        </div>
+    );
+};
+
+export default Label;


### PR DESCRIPTION
## 개요

공통 UI로 사용할 수 있는 Input, Label 컴포넌트를 추가했습니다.
Input 과 Label 를 같이 사용할 수도 있고, Input 만 별도로 사용할 수 있습니다. 


## 주요 변경사항

Input 컴포넌트 추가

variant prop을 통해 filled와 outlined 스타일 지원

renderRight prop을 통해 입력 필드 우측에 버튼 등 요소 삽입 가능

hasError prop으로 에러 상태 시 스타일 변경​

Label 컴포넌트 추가

direction prop을 통해 레이블과 입력 필드의 배치 방향 설정 (row 또는 column)

bottomText prop으로 입력 필드 하단에 에러 메시지 등 추가 정보 표시

## 사용 예시
```
<Label label="닉네임을 입력해주세요" bottomText="동일한 닉네임이 존재합니다.">
  <Input
    placeholder="닉네임을 입력해주세요"
    hasError={true}
    renderRight={<Button size="md">닉네임 확인</Button>}
  />
</Label>

<Label label="이메일" direction="row" bottomText="이메일을 올바르게 작성해주세요.">
  <Input placeholder="이메일을 입력해주세요" variant="outlined" hasError={true} />
</Label>

<Input placeholder="닉네임" variant="outlined"/>

```