### PR TITLE
Feat : Textarea 컴포넌트 구현

### DIFF
--- a/fitple/components/Textarea/Textarea.module.scss
+++ b/fitple/components/Textarea/Textarea.module.scss
@@ -1,0 +1,48 @@
+.textarea {
+    width: 100%;
+    padding: 1rem;
+    font-size: calc(var(--content-size) * 0.75);
+    line-height: 1.5;
+
+    border-radius: 0.5rem;
+    background-color: var(--font-white-color);
+    color: var(--font-black-color);
+    resize: none;
+    overflow-y: auto;
+    transition: border-color 0.2s;
+
+    &:focus {
+        border-color: var(--brand-color);
+        outline: none;
+    }
+
+    &:disabled {
+        background-color: var(--disabled-color);
+        cursor: not-allowed;
+    }
+
+    /* 스크롤바 스타일링 */
+    scrollbar-width: thin;
+    scrollbar-color: var(--scroll-thumb-color) var(--scroll-track-color);
+
+    &::-webkit-scrollbar {
+        width: 0.5rem;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: var(--scroll-track-color);
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background-color: var(--scroll-thumb-color);
+        border-radius: 0.25rem;
+    }
+}
+
+.sm {
+    height: 144px;
+}
+
+.md {
+    height: 210px;
+}

--- a/fitple/components/Textarea/Textarea.tsx
+++ b/fitple/components/Textarea/Textarea.tsx
@@ -1,0 +1,14 @@
+import { TextareaHTMLAttributes } from 'react';
+import styles from './Textarea.module.scss';
+
+interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+    size?: 'sm' | 'md';
+}
+
+const Textarea: React.FC<Props> = (props) => {
+    const { size = 'sm', ...rest } = props;
+
+    return <textarea className={`${styles.textarea} ${styles[size]}`} {...rest} />;
+};
+
+export default Textarea;


### PR DESCRIPTION
## 개요

공용 Textarea 컴포넌트를 추가했습니다. 

## 주요 변경사항

Textarea 컴포넌트 추가

HTML 기본 textarea의 속성을 모두 받을 수 있도록 타입을 확장했습니다.
size 를  prop으로 받아 높이만 다르게 주었습니다. 
size 는 sm 과 md 선택 가능하며 기본값은 sm 입니다. 

## 사용법

```
<Textarea placeHolder="내용을 입력해주세요" />

<Textarea size="md" placeHolder="내용을 입력해주세요" />
```