### PR TITLE
Fix : Label 컴포넌트에 hasError prop 추가작업

### DIFF
--- a/fitple/components/Input/Input.module.scss
+++ b/fitple/components/Input/Input.module.scss
@@ -29,6 +29,7 @@
     border-bottom: 1px solid var(--mobile-input-color); /* 올바른 CSS 변수 */
     border-radius: 0px;
     color: var(--mobile-input-color); /* 올바른 CSS 변수 */
+    background-color: transparent;
 }
 .error {
     color: var(--cancel-button-color);

--- a/fitple/components/Input/Label.tsx
+++ b/fitple/components/Input/Label.tsx
@@ -6,10 +6,11 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
     children: ReactNode;
     bottomText?: string;
     direction?: 'row' | 'column';
+    hasError?: boolean;
 }
 
 const Label: React.FC<Props> = (props) => {
-    const { label, children, bottomText, direction = 'column' } = props;
+    const { label, children, bottomText, direction = 'column', hasError } = props;
 
     return (
         <div className={`${styles.layout}`}>
@@ -17,7 +18,7 @@ const Label: React.FC<Props> = (props) => {
                 <label className={styles.label}>{label}</label>
                 {children}
             </div>
-            {bottomText != null ? <p className={styles.hasError}>{bottomText}</p> : null}
+            {hasError && bottomText ? <p className={styles.hasError}>{bottomText}</p> : null}
         </div>
     );
 };


### PR DESCRIPTION
## 변경 사항

Label 컴포넌트에 hasError? prop 을 추가했습니다.

## 사용 방법

아래와 같이 Label 컴포넌트에도 hasError 값을 넣어줘야 합니다. 

```
<Label label="닉네임" hasError={true} bottomText='닉네임이 존재합니다">
   <Input hasError={true}  placeholder="닉네임을 입력해주세요" />
</Label>

```

