### PR TITLE
Feat: Mypage의 팀 프로젝트 탭에서 사용할 백엔드 로직 구현

### DIFF
--- a/fitple/app/api/projects/[id]/route.ts
+++ b/fitple/app/api/projects/[id]/route.ts
@@ -1,0 +1,18 @@
+import { TeamDetailUsecase } from '@/back/team/application/usecases/TeamDetailUsecase';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const userId = params.id;
+
+  if (!userId) {
+    return NextResponse.json({ message: 'userId가 필요합니다.' }, { status: 400 });
+  }
+
+  const usecase = new TeamDetailUsecase();
+  const result = await usecase.execute(userId);
+
+  return NextResponse.json(result);
+}

--- a/fitple/app/api/projects/route.ts
+++ b/fitple/app/api/projects/route.ts
@@ -1,0 +1,16 @@
+import { TeamListUsecase } from '@/back/team/application/usecases/TeamListUsecase';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+
+  if (!userId) {
+    return NextResponse.json({ message: 'userId가 필요합니다.' }, { status: 400 });
+  }
+
+  const usecase = new TeamListUsecase();
+  const result = await usecase.execute(userId);
+
+  return NextResponse.json(result);
+}

--- a/fitple/back/team/application/usecases/TeamDetailUsecase.ts
+++ b/fitple/back/team/application/usecases/TeamDetailUsecase.ts
@@ -1,0 +1,43 @@
+import { TeamDetailDTO } from '@/back/team/application/usecases/dto/TeamDetailDto';
+import { createClient } from '@/utils/supabase/server';
+
+export class TeamDetailUsecase {
+  async execute(userId: string): Promise<TeamDetailDTO[]> {
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from('team')
+      .select(`
+        user:user_id (
+          nickname,
+          avatar_url,
+          user_position (
+            position:position_id (
+              position_name
+            )
+          ),
+          user_skill (
+            skill:skill_id (
+              skill_name
+            )
+          )
+        )
+      `)
+      .eq('user_id', userId);
+
+    if (error || !data) {
+      console.error('Error in TeamDetailUsecase:', error.message);
+      return [];
+    }
+
+    return data.map((item: any) => ({
+      userNickname: item.user.nickname,
+      userAvatarUrl: item.user.avatar_url,
+      userPosition: item.user.user_position?.[0]?.position?.position_name ?? '',
+      userSkill: item.user.user_skill
+        ?.map((us: any) => us.skill?.skill_name)
+        .filter(Boolean)
+        .join(', ') ?? '',
+    }));
+  }
+}

--- a/fitple/back/team/application/usecases/TeamListUsecase.ts
+++ b/fitple/back/team/application/usecases/TeamListUsecase.ts
@@ -1,0 +1,25 @@
+import { TeamListDTO } from '@/back/team/application/usecases/dto/TeamListDto'
+import { createClient } from '@/utils/supabase/server';
+
+export class TeamListUsecase {
+  async execute(userId: string): Promise<TeamListDTO[]> {
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from('team')
+      .select(`
+        id,
+        project:project_id ( title ),
+        user:user_id ( avatar_url )
+      `)
+      .eq('user_id', userId);
+
+    if (error || !data) return [];
+
+    return data.map((item: any) => ({
+      id: item.id,
+      projectTitle: item.project?.title ?? '제목 없음',
+      avatarUrl: item.user?.avatar_url ?? '',
+    }));
+  }
+}

--- a/fitple/back/team/application/usecases/dto/TeamDetailDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamDetailDto.ts
@@ -1,6 +1,8 @@
-export type TeamDetailDTO = {
-    userNickname: string;
-    userAvatarUrl: string;
-    userPosition: string;
-    userSkill: string;
-  };
+export class TeamDetailDTO {
+  constructor(
+    public userNickname: string,
+    public userAvatarUrl: string,
+    public userPosition: string,
+    public userSkill: string
+  ) {}
+}

--- a/fitple/back/team/application/usecases/dto/TeamDetailDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamDetailDto.ts
@@ -1,0 +1,6 @@
+export type TeamDetailDTO = {
+    userNickname: string;
+    userAvatarUrl: string;
+    userPosition: string;
+    userSkill: string;
+  };

--- a/fitple/back/team/application/usecases/dto/TeamListDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamListDto.ts
@@ -1,6 +1,8 @@
-export type TeamListDTO = {
-    id: number;
-    projectTitle: string;
-    avatarUrl: string;
+export class TeamListDTO {
+  constructor (
+    public id: number,
+    public projectTitle: string,
+    public avatarUrl: string,
+   ) {}
   };
   

--- a/fitple/back/team/application/usecases/dto/TeamListDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamListDto.ts
@@ -1,0 +1,6 @@
+export type TeamListDTO = {
+    id: number;
+    projectTitle: string;
+    avatarUrl: string;
+  };
+  

--- a/fitple/back/team/domain/entities/Team.ts
+++ b/fitple/back/team/domain/entities/Team.ts
@@ -1,0 +1,7 @@
+export class Team {
+    constructor(
+      public id: string,
+      public project_id: string,
+      public img_url: string,
+    ) {}
+  };

--- a/fitple/back/team/domain/entities/Team.ts
+++ b/fitple/back/team/domain/entities/Team.ts
@@ -1,7 +1,8 @@
 export class Team {
-    constructor(
-      public id: string,
-      public project_id: string,
-      public img_url: string,
-    ) {}
-  };
+  constructor(
+    public id: number,
+    public user_id: string,
+    public project_id: number,
+    public created_at: Date,
+  ) {}
+}

--- a/fitple/back/team/domain/repositories/TeamRepository.ts
+++ b/fitple/back/team/domain/repositories/TeamRepository.ts
@@ -1,0 +1,5 @@
+import { Team } from '../entities/Team';
+
+export interface TeamRepository {
+  
+}

--- a/fitple/back/team/domain/repositories/TeamRepository.ts
+++ b/fitple/back/team/domain/repositories/TeamRepository.ts
@@ -1,5 +1,5 @@
 import { Team } from '../entities/Team';
 
 export interface TeamRepository {
-  
+  findByUserId(userId: string): Promise<Team[]>;
 }

--- a/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
+++ b/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
@@ -1,0 +1,5 @@
+import { TeamRepository } from '../../../domain/repositories/TeamRepository';
+
+export class SbTeamRepository implements TeamRepository {
+    
+}

--- a/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
+++ b/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
@@ -1,5 +1,28 @@
-import { TeamRepository } from '../../../domain/repositories/TeamRepository';
+// infra/repositories/supabase/SbTeamRepository.ts
+
+import { Team } from '@/back/team/domain/entities/Team';
+import { TeamRepository } from '@/back/team/domain/repositories/TeamRepository';
+import { createClient } from '@/utils/supabase/server';
 
 export class SbTeamRepository implements TeamRepository {
-    
+  async findByUserId(userId: string): Promise<Team[]> {
+    const supabase = await createClient();
+
+    const { data, error } = await supabase
+      .from('team')
+      .select('*')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('findByUserId Error:', error.message);
+      return [];
+    }
+
+    if (!data) return [];
+
+    return data.map(
+      (item) =>
+        new Team(item.id, item.user_id, item.project_id, new Date(item.created_at))
+    );
+  }
 }


### PR DESCRIPTION
## 개요

마이페이지(`MyPage`) 내 '팀 프로젝트' 탭에서 사용자에게 관련 팀 정보를 보여주기 위해 필요한 백엔드 연동 로직을 구현했습니다. 
이를 통해 사용자의 팀 참여 현황을 실시간으로 조회할 수 있도록 구성했습니다.

## 주요 변경사항

- 마이페이지의 '팀 프로젝트' 탭에 사용할 API 연동 로직 추가
  - 사용자 ID를 기반으로 팀 참여 정보를 조회
  - 응답 형태는 `TeamListDto`를 따름
