### PR TITLE
Fix: MyPage에서 Header, FloatButton 및 하위 탭들 수정

### DIFF
--- a/fitple/app/mypage/edit/edit.module.scss
+++ b/fitple/app/mypage/edit/edit.module.scss
@@ -3,7 +3,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    width: 20vw;
+    width: 30vw;
     height: auto;
     gap: 1vw;
 }
@@ -18,24 +18,6 @@
     background-repeat: no-repeat;
 }
 
-.imageEditButton {
-    width: 50%;
-    padding: 0.5vw 2vw;
-    margin: 1vw 0;
-    text-align: center;
-    font-size: var(--content-size);
-    font-weight: bold;
-    color: var(--black-color);
-    background-color: var(--confirm-button-color);
-    border: none;
-    border-radius: 10px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-
-    &:hover {
-        background-color: #0056b3;
-    }
-}
 
 .editForm {
     width: 100%;

--- a/fitple/app/mypage/edit/page.tsx
+++ b/fitple/app/mypage/edit/page.tsx
@@ -1,36 +1,151 @@
+"use client";
+
 import styles from './edit.module.scss';
+import Label from '@/components/Input/Label';
+import Input from '@/components/Input/Input';
+import Select from '@/components/Select/Select';
+import Option from '@/components/Select/Option';
+import { useAuthStore } from '@/stores/authStore';
+import { useState } from 'react';
+import Button from '@/components/Button/Button';
 
 const EditInfoPage = () => {
+    const userNickname = useAuthStore((state) => state.nickname);
+    const userCareer = useAuthStore((state) => state.career);
+    const userPosition = useAuthStore((state) => state.position);
+
+    const [nickname, setNickname] = useState(userNickname || '');
+    const [career, setCareer] = useState<number | ''>(userCareer ?? '');
+    const [position, setPosition] = useState<string>(userPosition || '');
+
+    const [bottomText, setBottomText] = useState('닉네임을 입력해주세요');
+    const [error, setError] = useState(false);
+    const [isCompleted, setIsCompleted] = useState(false);
+
+    const handleCareerChange = (value: number) => {
+        setCareer(value);
+    };
+
+    const handlePositionChange = (value: string) => {
+        setPosition(value);
+    };
+
+    const handleNicknameCheck = async () => {
+        if (!nickname) {
+            setBottomText('닉네임을 입력해주세요.');
+            setError(true);
+            setIsCompleted(false);
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/namecheck', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ nickname }),
+            });
+
+            if (!response.ok) throw new Error('서버 오류');
+
+            const data = await response.json();
+
+            if (data.exists) {
+                setBottomText('이미 존재하는 닉네임입니다.');
+                setError(true);
+                setIsCompleted(false);
+            } else {
+                setBottomText('사용 가능한 닉네임입니다.');
+                setError(false);
+                setIsCompleted(true);
+            }
+        } catch (e) {
+            setBottomText('서버 오류가 발생했습니다.');
+            setError(true);
+            setIsCompleted(false);
+        }
+    };
+
     return (
         <div className={styles.myInfoContainer}>
             <div className={styles.imageBox}></div>
-            <div className={styles.imageEditButton}>사진 변경하기</div>
             <div className={styles.editForm}>
                 <form>
                     <div className={styles.formGroup}>
-                        <label htmlFor="nickname" className={styles.formLabel}>닉네임</label>
-                        <input type="text" id="nickname" name="nickname" placeholder="닉네임을 입력하세요" className={styles.formInput} />
+                        <Label label="닉네임" direction='row' bottomText={bottomText} hasError={error}>
+                            <Input
+                                placeholder="닉네임을 입력하세요"
+                                value={nickname}
+                                onChange={(e) => setNickname(e.target.value)}
+                                renderRight={
+                                    <Button type="button" size="sm" onClick={handleNicknameCheck}>
+                                        중복 확인
+                                    </Button>
+                                }
+                            />
+                        </Label>
                     </div>
+
                     <div className={styles.formGroup}>
-                        <label htmlFor="career" className={styles.formLabel}>경력</label>
-                        <input type="text" id="career" name="career" placeholder="경력을 입력하세요" className={styles.formInput} />
+                        <Label label="경력" />
+                        <Select
+                            onChange={(value) => handleCareerChange(Number(value))}
+                            value={career}
+                            placeholder="경력을 선택해주세요"
+                            options={careerOptions}
+                        >
+                            {careerOptions.map((option) => (
+                                <Option key={option.value} value={option.value}>
+                                    {option.label}
+                                </Option>
+                            ))}
+                        </Select>
                     </div>
+
                     <div className={styles.formGroup}>
-                        <label htmlFor="job" className={styles.formLabel}>직무</label>
-                        <input type="text" id="job" name="job" placeholder="직무를 입력하세요" className={styles.formInput} />
+                        <Label label="직무" />
+                        <Select
+                            onChange={(value) => handlePositionChange(value)}
+                            value={position}
+                            placeholder="직무를 선택해주세요"
+                            options={positionOptions}
+                        >
+                            {positionOptions.map((option) => (
+                                <Option key={option.value} value={option.value}>
+                                    {option.label}
+                                </Option>
+                            ))}
+                        </Select>
                     </div>
+
                     <div className={styles.formGroup}>
-                        <label htmlFor="techStack" className={styles.formLabel}>기술 스택</label>
-                        <input type="text" id="techStack" name="techStack" placeholder="기술 스택을 입력하세요" className={styles.formInput} />
+                        <Label label="기술스택" />
+                        {/* 기술스택 들어갈 곳 */}
                     </div>
+
                     <div className={styles.buttonGroup}>
-                        <button type="submit" className={styles.cancelButton}>취소</button>
+                        <button type="button" className={styles.cancelButton}>취소</button>
                         <button type="submit" className={styles.submitButton}>저장</button>
                     </div>
                 </form>
             </div>
         </div>
     );
-}
+};
 
 export default EditInfoPage;
+
+// 셀렉트 옵션 정의
+const careerOptions = Array.from({ length: 6 }, (_, i) => ({
+    value: i,
+    label: i === 0 ? '신입' : `${i}년차`,
+}));
+
+const positionOptions = [
+    { value: '프론트엔드', label: '프론트엔드' },
+    { value: '백엔드', label: '백엔드' },
+    { value: 'UI/UX 디자이너', label: 'UI/UX 디자이너' },
+    { value: 'PM', label: 'PM' },
+    { value: '기획자', label: '기획자' },
+];

--- a/fitple/app/mypage/page.module.scss
+++ b/fitple/app/mypage/page.module.scss
@@ -12,11 +12,11 @@
     width: 12vw;
     height: 12vw;
     border-radius: 50%;
-    background-image: url('/images/test-team.png');
     background-position: center;
     background-size: cover;
     background-repeat: no-repeat;
-}
+  }
+  
 
 .userInfo {
     display: flex;

--- a/fitple/app/mypage/page.tsx
+++ b/fitple/app/mypage/page.tsx
@@ -1,21 +1,49 @@
-import styles from './page.module.scss'
+"use client";
+
+import styles from './page.module.scss';
 import Link from 'next/link';
+import { useAuthStore } from '@/stores/authStore';
+import SkillBadge from '@/components/Badge/SkillBadge';
 
 export default function RootMyPage() {
+    const nickname = useAuthStore((state) => state.nickname);
+    const career = useAuthStore((state) => state.career);
+    const position = useAuthStore((state) => state.position);
+    const skills = useAuthStore((state) => state.skills);
+    const avatarUrl = useAuthStore((state) => state.avatarUrl);
+
     return (
         <div className={styles.myInfoContainer}>
-            <div className={styles.imageBox}></div>
+            <div
+                className={styles.imageBox}
+                style={{
+                    backgroundImage: `url(${avatarUrl || '/images/default-avatar.png'})`
+                }}
+            ></div>
+
             <div className={styles.userInfo}>
-                <span className={styles.userNickname}>하랑이</span>
+                <span className={styles.userNickname}>{nickname ?? '닉네임 없음'}</span>
                 <div className={styles.userPosicareerContainer}>
-                    <span className={styles.userPosicareer}>프론트엔드 개발자</span>
-                    <span className={styles.userPosicareer}>신입</span>
+                    <span className={styles.userPosicareer}>{position || '포지션 없음'}</span>
+                    <span className={styles.userPosicareer}>
+                        {career !== null ? (career === 0 ? '신입' : `${career}년차`) : '경력 없음'}
+                    </span>
                 </div>
             </div>
-            <Link href={'/mypage/edit'} className={styles.editButton}>수정하기</Link>
+
+            <Link href='/mypage/edit' className={styles.editButton}>수정하기</Link>
+
             <div className={styles.stackContainer}>
                 <span className={styles.stackHeader}>나의 기술스택은?</span>
-                <div className={styles.stackBox}>기술스택 들어갈 곳입니다.</div>
+                <div className={styles.stackBox}>
+                    {skills.length > 0 ? (
+                        skills.map((skill, idx) => (
+                            <SkillBadge key={idx} name={skill} label={skill} />
+                        ))
+                    ) : (
+                        <span className={styles.noSkillText}>기술스택 정보가 없습니다.</span>
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/fitple/back/user/application/usecases/dto/UserUpdateDto.ts
+++ b/fitple/back/user/application/usecases/dto/UserUpdateDto.ts
@@ -1,0 +1,10 @@
+export class UserUpdateDto {
+    constructor(
+        public nickname: string,
+        public career: string,
+        public position: string,
+        public avatarUrl: string,
+        public skills: { id: number; name: string }[],
+        public positions: { id: number; name: string }[],
+    ) {}
+}

--- a/fitple/components/FloatButton/FloatButton.tsx
+++ b/fitple/components/FloatButton/FloatButton.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import styles from './FloatButton.module.scss';
 import Image from 'next/image';
+import Link from 'next/link';
 
 const FloatButton: React.FC = () => {
     const [open, setOpen] = useState(false);
@@ -14,12 +15,12 @@ const FloatButton: React.FC = () => {
     return (
         <div className={styles.floatContainer}>
             <div className={`${styles.additionalButton} ${open ? styles.show : ''}`}>
-                <button className={styles.floatButtonProfile}>
+                <Link href="board/introduction/write" className={styles.floatButtonProfile}>
                     <Image src="/images/account.png" alt="Profile" width={24} height={24} />
-                </button>
-                <button className={styles.floatButtonProject}>
-                <Image src="/images/team.png" alt="Profile" width={24} height={24} />
-                </button>
+                </Link>
+                <Link href="board/project/write" className={styles.floatButtonProject}>
+                <Image src="/images/team.png" alt="Project" width={24} height={24} />
+                </Link>
             </div>
             <button className={styles.floatButton} onClick={toggleButtons}>
                 <Image src="/images/pencil.png" alt="Add" width={24} height={24} />

--- a/fitple/components/Header/Header.module.scss
+++ b/fitple/components/Header/Header.module.scss
@@ -43,3 +43,14 @@
 
   cursor: pointer;
 }
+
+.welcomeText {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--white-color);
+  background-color: transparent;
+  border: none;
+  cursor: default;
+  display: flex;
+  align-items: center;
+}

--- a/fitple/components/Header/Header.module.scss
+++ b/fitple/components/Header/Header.module.scss
@@ -44,6 +44,18 @@
   cursor: pointer;
 }
 
+.loginText {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--white-color);
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
 .welcomeText {
   font-size: 16px;
   font-weight: 600;

--- a/fitple/components/Header/Header.tsx
+++ b/fitple/components/Header/Header.tsx
@@ -13,12 +13,14 @@ const Header = () => {
 
     return (
         <div className={styles.headerContainer}>
-            <Image
-                src="/images/logo-blue.png"
-                alt="logo"
-                width={120}
-                height={50}
-            />
+            <Link href="/">
+                <Image
+                    src="/images/logo-blue.png"
+                    alt="logo"
+                    width={120}
+                    height={50}
+                />
+            </Link>
             <ul className={styles.ulStyles}>
                 {isAuthenticated() ? (
                     <>
@@ -26,14 +28,12 @@ const Header = () => {
                             {nickname}님 환영합니다!
                         </li>
                         <Link href="/mypage">
-                            <li><div className={styles.userIcon} /></li>
+                            <div className={styles.userIcon} />
                         </Link>
-                        <li><div className={styles.notificationIcon} /></li>
+                        <div className={styles.notificationIcon} />
                     </>
                 ) : (
-                    <Link href="/login">
-                        <li className={styles.loginText}>로그인</li>
-                    </Link>
+                    <Link href="/login" className={styles.loginText}>로그인</Link>
                 )}
             </ul>
         </div>

--- a/fitple/components/Header/Header.tsx
+++ b/fitple/components/Header/Header.tsx
@@ -1,7 +1,16 @@
+"use client";
+
 import styles from './Header.module.scss';
 import Image from 'next/image';
+import { useAuthStore } from '@/stores/authStore';
+import Link from 'next/link';
 
 const Header = () => {
+    const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+    const nickname = useAuthStore((state) => state.nickname);
+
+    console.log(nickname)
+
     return (
         <div className={styles.headerContainer}>
             <Image
@@ -9,10 +18,23 @@ const Header = () => {
                 alt="logo"
                 width={120}
                 height={50}
-             />
+            />
             <ul className={styles.ulStyles}>
-                <li><div className={`${styles.userIcon}`} /></li>
-                <li><div className={`${styles.notificationIcon}`} /></li>
+                {isAuthenticated() ? (
+                    <>
+                        <li className={styles.welcomeText}>
+                            {nickname}님 환영합니다!
+                        </li>
+                        <Link href="/mypage">
+                            <li><div className={styles.userIcon} /></li>
+                        </Link>
+                        <li><div className={styles.notificationIcon} /></li>
+                    </>
+                ) : (
+                    <Link href="/login">
+                        <li className={styles.loginText}>로그인</li>
+                    </Link>
+                )}
             </ul>
         </div>
     );


### PR DESCRIPTION
## 개요

마이페이지의 '내 정보' 및 '내 정보 수정' 화면을 구현하고, 관련된 공통 컴포넌트 및 라우팅 기능을 개선했습니다. 또한 `Header`와 `FloatButton`의 인터랙션을 개선하여 UX를 향상시켰습니다.

## 주요 변경사항

- `내 정보`, `내 정보 수정` 페이지 구현 및 공통 컴포넌트로 수정
- `Header` 컴포넌트에 로그인 상태 확인 로직 추가
  - 로그인 여부에 따라 조건부 UI 렌더링 가능
  - 로고 클릭 시 루트(`/`) 페이지로 이동하도록 설정
- `FloatButton` 클릭 시 글 작성 페이지(`/write`)로 이동하도록 라우팅 처리

## 사용

- 로그인 여부에 따라 `Header` 우측에 닉네임 또는 '로그인 하기' 렌더링
- `FloatButton`은 모든 페이지에서 고정 위치에 표시되며, 클릭 시 버튼에 따라 project or introduction `/write` 경로로 이동
- `MyPage` 내 정보 관련 화면은 공통 컴포넌트로 수정
