### PR TITLE
Fix: 마이페이지에 팀 프로젝트 탭 구현 완료

### DIFF
--- a/fitple/app/mypage/page.tsx
+++ b/fitple/app/mypage/page.tsx
@@ -17,7 +17,7 @@ export default function RootMyPage() {
             <div
                 className={styles.imageBox}
                 style={{
-                    backgroundImage: `url(${avatarUrl || '/images/default-avatar.png'})`
+                    backgroundImage: `url(${avatarUrl || '/images/test-team.png'})`
                 }}
             ></div>
 
@@ -38,7 +38,7 @@ export default function RootMyPage() {
                 <div className={styles.stackBox}>
                     {skills.length > 0 ? (
                         skills.map((skill, idx) => (
-                            <SkillBadge key={idx} name={skill} label={skill} />
+                            <SkillBadge type='icon' iconLogoSize={60} key={idx} name={skill} label={skill} />
                         ))
                     ) : (
                         <span className={styles.noSkillText}>기술스택 정보가 없습니다.</span>

--- a/fitple/app/mypage/team/[id]/page.module.scss
+++ b/fitple/app/mypage/team/[id]/page.module.scss
@@ -1,0 +1,51 @@
+.gridContainer {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 20px;
+  }
+  
+  .header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nicnamePostion {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 5px;
+  }
+  
+  .avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #eee;
+  }
+  
+  .nickname {
+    font-weight: bold;
+    font-size: 24px;
+  }
+  
+  .body {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 100%;
+    gap: 6px;
+  }
+  
+  .label {
+    font-weight: 500;
+    font-size: 10px;
+    color: #666;
+  }
+  
+  .imageBox {
+    border-radius: 50%;
+  }

--- a/fitple/app/mypage/team/[id]/page.tsx
+++ b/fitple/app/mypage/team/[id]/page.tsx
@@ -1,7 +1,95 @@
-const TeamProjectDetailPage = () => {
-    return (
-        <h1>팀 프로젝트 페이지 디테일 입니다.</h1>
-    );
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Card from '@/components/Card/Card';
+import styles from './page.module.scss';
+import Badge from '@/components/Badge/Badge';
+import SkillBadge from '@/components/Badge/SkillBadge';
+import Image from 'next/image';
+
+interface Member {
+  userNickname: string;
+  userAvatarUrl: string;
+  userPosition: string;
+  userSkill: string;
 }
+
+// ✅ 포지션 매핑
+const positionMap: { [key: string]: string } = {
+  FE: '프론트엔드',
+  BE: '백엔드',
+  PM: '프로젝트 매니저',
+  DI: '디자이너',
+  FS: '풀스택',
+};
+
+const TeamProjectDetailPage = () => {
+  const { id } = useParams();
+  const [members, setMembers] = useState<Member[]>([]);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      try {
+        const res = await fetch(`/api/member/teams/${id}`);
+        const data = await res.json();
+        setMembers(data);
+      } catch (err) {
+        console.error('팀원 불러오기 실패:', err);
+      }
+    };
+
+    if (id) fetchMembers();
+  }, [id]);
+
+  return (
+    <div className={styles.gridContainer}>
+      {members.map((member, index) => (
+        <Card
+          key={index}
+          header={
+            <div className={styles.header}>
+              <Badge backgroundColor="#FFA928">🦁 프로필</Badge>
+              <div className={styles.nicnamePostion}>
+                <div className={styles.nickname}>{member.userNickname}</div>
+                <div className={styles.label}>
+                  {positionMap[member.userPosition] || member.userPosition}
+                </div>
+              </div>
+            </div>
+          }
+          body={
+            <div className={styles.body}>
+              <Image
+                width={80}
+                height={80}
+                src={member.userAvatarUrl || '/images/test-team.png'}
+                alt="avatar"
+                className={styles.imageBox}
+              />
+            </div>
+          }
+          footer={
+            <div className={styles.skillWrapper}>
+              {member.userSkill
+                .split(',')
+                .map((skill) => skill.trim())
+                .filter((skill) => skill.length > 0)
+                .map((skill, idx) => (
+                  <SkillBadge
+                    type="icon"
+                    iconLogoSize={30}
+                    key={idx}
+                    name={skill}
+                    label={skill}
+                  />
+                ))}
+            </div>
+          }
+        />
+      ))}
+    </div>
+  );
+};
 
 export default TeamProjectDetailPage;

--- a/fitple/app/mypage/team/page.module.scss
+++ b/fitple/app/mypage/team/page.module.scss
@@ -1,0 +1,50 @@
+.gridContainer {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 20px;
+  }
+  
+  .customSpan {
+    font-size: 13px;
+  }
+  
+  .bodyBox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 80px;
+  }
+  
+  .projectTitle {
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+  }
+  
+  .footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 12px;
+
+    width: 100%;
+  }
+  
+  .avatarGroup {
+    display: flex;
+  }
+  
+  .avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid white;
+  }
+  
+  .date {
+    font-size: 12px;
+    color: #aaa;
+  }
+  

--- a/fitple/app/mypage/team/page.tsx
+++ b/fitple/app/mypage/team/page.tsx
@@ -1,7 +1,75 @@
-const TeamProjectListPage = () => {
-    return (
-        <h1>팀 프로젝트 페이지 리스트 입니다.</h1>
-    );
+'use client';
+
+import { useEffect, useState } from 'react';
+import Badge from '@/components/Badge/Badge';
+import Card from '@/components/Card/Card';
+import Image from 'next/image';
+import styles from './page.module.scss';
+import { useAuthStore } from '@/stores/authStore';
+import Link from 'next/link';
+
+interface TeamListDTO {
+    id: number;
+    projectId: number;
+    projectTitle: string;
+    avatarUrl: string;
 }
+
+const TeamProjectListPage = () => {
+    const userId = useAuthStore((state) => state.id);
+    const [teams, setTeams] = useState<TeamListDTO[]>([]);
+
+    useEffect(() => {
+        const fetchTeams = async () => {
+            try {
+                const res = await fetch(`/api/member/teams?userId=${userId}`);
+                const data = await res.json();
+                setTeams(data);
+                console.log(data);
+            } catch (error) {
+                console.error('팀 목록 불러오기 실패:', error);
+            }
+        };
+
+        if (userId) {
+            fetchTeams();
+        }
+    }, [userId]);
+
+    return (
+        <div className={styles.gridContainer}>
+            {teams.map((team) => (
+               <Link href={`/mypage/team/${team.projectId}`} key={team.id}>
+                    <Card
+                        key={team.id}
+                        header={
+                            <div>
+                                <Badge size="md">
+                                    <span className={styles.customSpan}>📂 프로젝트</span>
+                                </Badge>
+                            </div>
+                        }
+                        body={
+                            <div className={styles.bodyBox}>
+                                <p className={styles.projectTitle}>{team.projectTitle}</p>
+                            </div>
+                        }
+                        footer={
+                            <div className={styles.footer}>
+                                <div className={styles.avatarGroup}>
+                                    <img
+                                        src={team.avatarUrl}
+                                        alt="avatar"
+                                        className={styles.avatar}
+                                    />
+                                </div>
+                            </div>
+                        }
+                    />
+                </Link>
+            ))}
+        </div>
+    );
+};
 
 export default TeamProjectListPage;

--- a/fitple/back/team/application/usecases/TeamDetailUsecase.ts
+++ b/fitple/back/team/application/usecases/TeamDetailUsecase.ts
@@ -2,7 +2,7 @@ import { TeamDetailDTO } from '@/back/team/application/usecases/dto/TeamDetailDt
 import { createClient } from '@/utils/supabase/server';
 
 export class TeamDetailUsecase {
-  async execute(userId: string): Promise<TeamDetailDTO[]> {
+  async execute(projectId: string): Promise<TeamDetailDTO[]> {
     const supabase = await createClient();
 
     const { data, error } = await supabase
@@ -23,8 +23,7 @@ export class TeamDetailUsecase {
           )
         )
       `)
-      .eq('user_id', userId);
-
+      .eq('project_id', projectId);
     if (error || !data) {
       console.error('Error in TeamDetailUsecase:', error.message);
       return [];

--- a/fitple/back/team/application/usecases/TeamListUsecase.ts
+++ b/fitple/back/team/application/usecases/TeamListUsecase.ts
@@ -8,16 +8,18 @@ export class TeamListUsecase {
     const { data, error } = await supabase
       .from('team')
       .select(`
-        id,
-        project:project_id ( title ),
-        user:user_id ( avatar_url )
-      `)
+      id,
+      project_id,
+      project:project_id ( title ),
+      user:user_id ( avatar_url )
+    `)
       .eq('user_id', userId);
 
     if (error || !data) return [];
 
     return data.map((item: any) => ({
       id: item.id,
+      projectId: item.project_id,
       projectTitle: item.project?.title ?? '제목 없음',
       avatarUrl: item.user?.avatar_url ?? '',
     }));

--- a/fitple/back/team/application/usecases/dto/TeamListDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamListDto.ts
@@ -1,8 +1,8 @@
 export class TeamListDTO {
-  constructor (
+  constructor(
     public id: number,
+    public projectId: number,
     public projectTitle: string,
     public avatarUrl: string,
-   ) {}
-  };
-  
+  ) {}
+}

--- a/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
+++ b/fitple/back/team/infra/repositories/supabase/SbTeamRepository.ts
@@ -1,5 +1,3 @@
-// infra/repositories/supabase/SbTeamRepository.ts
-
 import { Team } from '@/back/team/domain/entities/Team';
 import { TeamRepository } from '@/back/team/domain/repositories/TeamRepository';
 import { createClient } from '@/utils/supabase/server';
@@ -13,8 +11,8 @@ export class SbTeamRepository implements TeamRepository {
       .select('*')
       .eq('user_id', userId);
 
-    if (error) {
-      console.error('findByUserId Error:', error.message);
+    if (error || !data) {
+      console.log('findByUserId Error:', error.message);
       return [];
     }
 

--- a/fitple/components/Badge/SkillBadge.tsx
+++ b/fitple/components/Badge/SkillBadge.tsx
@@ -6,13 +6,14 @@ type Props = {
     name: string;
     label?: string;
     logoSize?: number;
+    iconLogoSize?: number;
 };
 
 const SkillBadge = (props: Props) => {
-    const { type = 'label', name, label, logoSize = 45, ...rest } = props;
+    const { type = 'label', name, label, logoSize = 45,iconLogoSize=30, ...rest } = props;
 
     return type === 'icon' ? (
-        <Image src={`/images/${name}.svg`} width={30} height={30} alt={name} className={styles.skillLogo} {...rest} />
+        <Image src={`/images/${name}.svg`} width={iconLogoSize} height={iconLogoSize} alt={name} className={styles.skillLogo} {...rest} />
     ) : (
         <div className={styles.label} {...rest}>
             <Image


### PR DESCRIPTION
## 개요

`MyPage` 내 프로젝트 관련 정보를 보여주기 위한 "프로젝트" 탭 UI를 구현했습니다.  
해당 탭을 통해 사용자가 참여 중인 프로젝트 목록을 확인할 수 있도록 구성했습니다.
또한 프로젝트를 한번 더 클릭해서 참여 인원을 확인할 수 있습니다.

## 주요 변경사항

- `MyPage` 내 탭 구조 중 "프로젝트" 탭 레이아웃 및 컴포넌트 구현

## 사용

- `MyPage` 페이지 내부에서 탭 전환을 통해 "프로젝트" 탭으로 진입 가능
-  프로젝트를 들어가게 되면 참여중인 인원 확인 가능
