### PR TITLE
Fix: 마이페이지 내에 요청목록 탭 구현,차후 백엔드 연결 필요함

### DIFF
--- a/fitple/app/mypage/components/SubTabMenu.tsx
+++ b/fitple/app/mypage/components/SubTabMenu.tsx
@@ -12,6 +12,11 @@ const subTabs = {
         { href: '/mypage/mypost/projects', label: '작성한 프로젝트' },
         { href: '/mypage/mypost/profiles', label: '작성한 프로필' },
     ],
+    '/mypage/request': [
+        { href: '/mypage/request/projects', label: '프로젝트 요청' },
+        { href: '/mypage/request/profiles', label: '프로필 요청' },
+    ],
+
 };
 
 const SubTabMenu = () => {

--- a/fitple/app/mypage/components/TabMenu.tsx
+++ b/fitple/app/mypage/components/TabMenu.tsx
@@ -18,7 +18,7 @@ const TabMenu = () => {
         { href: "/mypage/edit", label: "내 정보 수정", exact: true },
         { href: "/mypage/likelist/projects", label: "찜한 항목" },
         { href: "/mypage/mypost/projects", label: "내 활동" },
-        { href: "/mypage/request", label: "요청 목록" },
+        { href: "/mypage/request/projects", label: "요청 목록" },
         { href: "/mypage/team", label: "팀 프로젝트" },
     ];
 

--- a/fitple/app/mypage/request/page.tsx
+++ b/fitple/app/mypage/request/page.tsx
@@ -1,7 +1,0 @@
-const RequestPage = () => {
-    return (
-        <h1>요청 목록 페이지 입니다.</h1>
-    );
-}
-
-export default RequestPage;

--- a/fitple/app/mypage/request/profiles/page.module.scss
+++ b/fitple/app/mypage/request/profiles/page.module.scss
@@ -1,0 +1,51 @@
+.gridContainer {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nicnamePostion {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 5px;
+}
+
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #eee;
+}
+
+.nickname {
+  font-weight: bold;
+  font-size: 24px;
+}
+
+.body {
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 6px;
+}
+
+.label {
+  font-weight: 500;
+  font-size: 10px;
+  color: #666;
+}
+
+.imageBox {
+  border-radius: 50%;
+}

--- a/fitple/app/mypage/request/profiles/page.tsx
+++ b/fitple/app/mypage/request/profiles/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import Card from '@/components/Card/Card';
+import styles from './page.module.scss';
+import Badge from '@/components/Badge/Badge';
+import SkillBadge from '@/components/Badge/SkillBadge';
+import Image from 'next/image';
+
+interface Member {
+  userNickname: string;
+  userAvatarUrl: string;
+  userPosition: string;
+  userSkill: string;
+}
+
+const positionMap: { [key: string]: string } = {
+  FE: '프론트엔드',
+  BE: '백엔드',
+  PM: '프로젝트 매니저',
+  DI: '디자이너',
+  FS: '풀스택',
+};
+
+const RequestProfilePage = () => {
+
+  return (
+    <div className={styles.gridContainer}>
+      {members.map((member, index) => (
+        <Card
+          key={index}
+          header={
+            <div className={styles.header}>
+              <Badge backgroundColor="#FFA928">🦁 프로필</Badge>
+              <div className={styles.nicnamePostion}>
+                <div className={styles.nickname}>{member.userNickname}</div>
+                <div className={styles.label}>
+                  {positionMap[member.userPosition] || member.userPosition}
+                </div>
+              </div>
+            </div>
+          }
+          body={
+            <div className={styles.body}>
+              <Image
+                width={80}
+                height={80}
+                src={member.userAvatarUrl || '/images/test-team.png'}
+                alt="avatar"
+                className={styles.imageBox}
+              />
+            </div>
+          }
+          footer={
+            <div className={styles.skillWrapper}>
+              {member.userSkill
+                .split(',')
+                .map((skill) => skill.trim())
+                .filter((skill) => skill.length > 0)
+                .map((skill, idx) => (
+                  <SkillBadge
+                    type="icon"
+                    iconLogoSize={30}
+                    key={idx}
+                    name={skill}
+                    label={skill}
+                  />
+                ))}
+            </div>
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+export default RequestProfilePage;

--- a/fitple/app/mypage/request/projects/page.module.scss
+++ b/fitple/app/mypage/request/projects/page.module.scss
@@ -1,0 +1,51 @@
+.gridContainer {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    padding: 20px;
+  }
+  
+  .header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .nicnamePostion {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 5px;
+  }
+  
+  .avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #eee;
+  }
+  
+  .nickname {
+    font-weight: bold;
+    font-size: 24px;
+  }
+  
+  .body {
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: 100%;
+    gap: 6px;
+  }
+  
+  .label {
+    font-weight: 500;
+    font-size: 10px;
+    color: #666;
+  }
+  
+  .imageBox {
+    border-radius: 50%;
+  }

--- a/fitple/app/mypage/request/projects/page.tsx
+++ b/fitple/app/mypage/request/projects/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Badge from '@/components/Badge/Badge';
+import Card from '@/components/Card/Card';
+import styles from './page.module.scss';
+import Link from 'next/link';
+
+interface Project {
+    id: number;
+    projectId: number;
+    projectTitle: string;
+    avatarUrl: string;
+}
+
+const RequestProjectPage = () => {
+
+    return (
+        <div className={styles.gridContainer}>
+            {teams.map((team) => (
+               <Link href={`/mypage/team/${team.projectId}`} key={team.id}>
+                    <Card
+                        key={team.id}
+                        header={
+                            <div>
+                                <Badge size="md">
+                                    <span className={styles.customSpan}>📂 프로젝트</span>
+                                </Badge>
+                            </div>
+                        }
+                        body={
+                            <div className={styles.bodyBox}>
+                                <p className={styles.projectTitle}>{team.projectTitle}</p>
+                            </div>
+                        }
+                        footer={
+                            <div className={styles.footer}>
+                                <div className={styles.avatarGroup}>
+                                    <img
+                                        src={team.avatarUrl}
+                                        alt="avatar"
+                                        className={styles.avatar}
+                                    />
+                                </div>
+                            </div>
+                        }
+                    />
+                </Link>
+            ))}
+        </div>
+    );
+};
+
+export default RequestProjectPage;


### PR DESCRIPTION
## 개요

`MyPage` 내에서 사용자의 요청 목록을 확인할 수 있는 "요청목록" 탭을 구현했습니다. 현재는 정적인 UI만 구성되어 있으며, 추후 백엔드와의 연동이 필요합니다.

## 주요 변경사항

- `MyPage` 탭 구조에 "요청목록" 탭 추가
-  SubTabMenu에 프로젝트 요청, 프로필 요청 추가
- 요청 리스트를 표시할 수 있는 레이아웃 및 컴포넌트 구성
- API 연동 전임

## 사용

- `MyPage` 내 탭을 통해 "요청목록" 화면으로 이동 가능
- 현재는 백엔드 API와의 연동은 되어 있지 않으며, 이후 데이터 바인딩 예정
