### PR TITLE
Fix: 마이페이지 팀 프로젝트 탭에서 팀에 소속된 모든 유저의 사진 보이게 수정

### DIFF
--- a/fitple/app/api/member/teams/[id]/route.ts
+++ b/fitple/app/api/member/teams/[id]/route.ts
@@ -5,7 +5,7 @@ export async function GET(
   req: Request,
   { params }: { params: { id: string } }
 ) {
-  const userId = params.id;
+  const { id: userId } = await params
 
   if (!userId) {
     return NextResponse.json({ message: 'userId가 필요합니다.' }, { status: 400 });

--- a/fitple/app/mypage/team/page.module.scss
+++ b/fitple/app/mypage/team/page.module.scss
@@ -47,4 +47,23 @@
     font-size: 12px;
     color: #aaa;
   }
+
+  .avatarGroup {
+    display: flex;
+    align-items: center;
+  }
+  
+  .avatarGroup .avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 2px solid #fff;
+    box-shadow: 0 0 0 1px #ccc;
+    margin-left: -12px;
+  }
+  
+  .avatarGroup .avatar:first-child {
+    margin-left: 0;
+  }
   

--- a/fitple/app/mypage/team/page.tsx
+++ b/fitple/app/mypage/team/page.tsx
@@ -12,7 +12,7 @@ interface TeamListDTO {
     id: number;
     projectId: number;
     projectTitle: string;
-    avatarUrl: string;
+    avatarUrls: string[]; 
 }
 
 const TeamProjectListPage = () => {
@@ -25,7 +25,6 @@ const TeamProjectListPage = () => {
                 const res = await fetch(`/api/member/teams?userId=${userId}`);
                 const data = await res.json();
                 setTeams(data);
-                console.log(data);
             } catch (error) {
                 console.error('팀 목록 불러오기 실패:', error);
             }
@@ -56,15 +55,18 @@ const TeamProjectListPage = () => {
                         }
                         footer={
                             <div className={styles.footer}>
-                                <div className={styles.avatarGroup}>
-                                    <img
-                                        src={team.avatarUrl || '/ㅑ'}
-                                        alt="avatar"
-                                        className={styles.avatar}
-                                    />
-                                </div>
+                              <div className={styles.avatarGroup}>
+                                {team.avatarUrls.map((url, index) => (
+                                  <img
+                                    key={index}
+                                    src={url}
+                                    alt={`team-member-${index}`}
+                                    className={styles.avatar}
+                                  />
+                                ))}
+                              </div>
                             </div>
-                        }
+                          }
                     />
                 </Link>
             ))}

--- a/fitple/back/team/application/usecases/TeamListUsecase.ts
+++ b/fitple/back/team/application/usecases/TeamListUsecase.ts
@@ -1,27 +1,48 @@
-import { TeamListDTO } from '@/back/team/application/usecases/dto/TeamListDto'
+import { TeamListDTO } from '@/back/team/application/usecases/dto/TeamListDto';
 import { createClient } from '@/utils/supabase/server';
 
 export class TeamListUsecase {
   async execute(userId: string): Promise<TeamListDTO[]> {
     const supabase = await createClient();
 
-    const { data, error } = await supabase
+    const { data: userTeams, error } = await supabase
       .from('team')
-      .select(`
-      id,
-      project_id,
-      project:project_id ( title ),
-      user:user_id ( avatar_url )
-    `)
+      .select('project_id')
       .eq('user_id', userId);
 
-    if (error || !data) return [];
+    if (error || !userTeams.length) return [];
 
-    return data.map((item: any) => ({
-      id: item.id,
-      projectId: item.project_id,
-      projectTitle: item.project?.title ?? '제목 없음',
-      avatarUrl: item.user?.avatar_url ?? '',
-    }));
+    const projectIds = userTeams.map((team) => team.project_id);
+
+    const { data: teamData, error: teamError } = await supabase
+      .from('team')
+      .select(`
+        id,
+        project_id,
+        project:project_id ( title ),
+        user:user_id ( avatar_url )
+      `)
+      .in('project_id', projectIds);
+
+    if (teamError || !teamData) return [];
+
+    const teamMap = new Map<number, TeamListDTO>();
+
+    teamData.forEach((item) => {
+      const existingTeam = teamMap.get(item.project_id);
+
+      if (existingTeam) {
+        existingTeam.avatarUrls.push(item.user?.avatar_url || '/images/test-team.png');
+      } else {
+        teamMap.set(item.project_id, {
+          id: item.id,
+          projectId: item.project_id,
+          projectTitle: item.project?.title ?? '제목 없음',
+          avatarUrls: [item.user?.avatar_url || '/images/test-team.png'],
+        });
+      }
+    });
+
+    return Array.from(teamMap.values());
   }
 }

--- a/fitple/back/team/application/usecases/dto/TeamListDto.ts
+++ b/fitple/back/team/application/usecases/dto/TeamListDto.ts
@@ -3,6 +3,6 @@ export class TeamListDTO {
     public id: number,
     public projectId: number,
     public projectTitle: string,
-    public avatarUrl: string,
+    public avatarUrl: string[],
   ) {}
 }


### PR DESCRIPTION
## ✨ Fix: 마이페이지 팀 프로젝트 탭에서 팀에 소속된 모든 유저의 사진 보이게 수정

### 📌 변경 내용

- 마이페이지 내 **팀 프로젝트 탭**에서 완료된 팀 목록을 확인할 수 있도록 구현됨
- 각 팀 카드에 표시되는 **참여 유저의 사진**이 기존에는 한 명만 출력되던 문제 수정
- 이제 **참여한 모든 유저의 사진이 카드에 표시**되도록 동작