### PR TITLE
Fix: 카드 컴포넌트 size props 추가

### DIFF
--- a/fitple/components/Card/Card.module.scss
+++ b/fitple/components/Card/Card.module.scss
@@ -45,3 +45,18 @@
     font-size: 0.8125rem;
 }
 
+// 크기 별 클래스
+.sm {
+    width: 18rem;  // 약 70%
+    height: 1rem;
+}
+
+.md {
+    width: 20.75rem; // 기본 크기
+    height: 12.5rem;
+}
+
+.lg {
+    width: 26rem; // 필요하면 추가
+    height: 15rem;
+}

--- a/fitple/components/Card/Card.tsx
+++ b/fitple/components/Card/Card.tsx
@@ -1,15 +1,16 @@
-import React, { FC, ReactNode } from "react";
-import styles from "./Card.module.scss";
+import React, { FC, ReactNode } from 'react';
+import styles from './Card.module.scss';
 
 type CardProps = {
     header?: ReactNode; // 상단 커스터마이징
     body: ReactNode; // 본문 커스터마이징
     footer?: ReactNode; // 하단 커스터마이징
+    size?: 'sm' | 'md' | 'lg'; // 버튼 크기
 };
 
-const Card: FC<CardProps> = ({ header, body, footer, ...props }) => {
+const Card: FC<CardProps> = ({ header, body, footer, size = 'md', ...props }) => {
     return (
-        <div className={styles.card} {...props}>
+        <div className={`${styles.card} ${styles[size]}`} {...props}>
             {/* 상단: header는 있으면 렌더링 */}
             <div className={styles.cardHeader}>{header}</div>
 


### PR DESCRIPTION
## 변경 사항
카드 컴포넌트의 size를 조절할 수 있게 props를 추가하였습니다.

## 사용 예시
```tsx
<Card
  size="sm"
  header={<div>헤더</div>}
  body={<div>내용</div>}
  footer={<div>푸터</div>}
/>